### PR TITLE
Parry Method on Projectile.cs

### DIFF
--- a/Assets/Scripts/Projectile.cs
+++ b/Assets/Scripts/Projectile.cs
@@ -33,4 +33,15 @@ public class Projectile : MonoBehaviour
             Destroy(gameObject);
         }
     }
+
+    public void Parry()
+    {
+        BulletHit();
+    }
+
+    public void BulletHit()
+    {
+        Destroy(gameObject);
+    }
+
 }


### PR DESCRIPTION
I added a public method called Parry that you can call on the projectile to destroy it on trigger enter via the weapon script.